### PR TITLE
Fix device map offloading error

### DIFF
--- a/gpt5.2_finetune-possibly-the-best-one.py
+++ b/gpt5.2_finetune-possibly-the-best-one.py
@@ -102,6 +102,9 @@ class Args:
     hf_token: Optional[str] = os.environ.get("HF_TOKEN")
     max_shard_size: str = "2GB"
 
+    # Offloading
+    offload_dir: str = "./offload"
+
 
 def parse_args(argv: List[str]) -> Args:
     import argparse
@@ -117,6 +120,7 @@ def parse_args(argv: List[str]) -> Args:
     p.add_argument("--merged-path", type=str, default=None)
     p.add_argument("--lora-ckpt-dir", type=str, default=None)
     p.add_argument("--output-dir", type=str, default=None)
+    p.add_argument("--offload-dir", type=str, default=None)
 
     # LoRA
     p.add_argument("--lora-r", type=int, default=None)
@@ -436,6 +440,7 @@ def build_reward(args: Args):
         args.reward_model_id,
         torch_dtype=torch.bfloat16,
         device_map="auto",
+        offload_folder=args.offload_dir,
     )
     inc = tok.convert_tokens_to_ids("<INCORRECT>")
     cor = tok.convert_tokens_to_ids("<CORRECT>")
@@ -470,6 +475,7 @@ def ppo_train(args: Args, merged_path: str, sft_prompts: List[str]):
         merged_path,
         torch_dtype=torch.bfloat16,
         device_map="auto",
+        offload_folder=args.offload_dir,
     )
     ref_model = create_reference_model(ppo_model)
 
@@ -621,6 +627,7 @@ def main(argv: List[str]):
     args = parse_args(argv)
     set_seed(args.seed)
     os.makedirs(args.output_dir, exist_ok=True)
+    os.makedirs(args.offload_dir, exist_ok=True)
 
     write_manifest(args, stage="start", extra={})
 


### PR DESCRIPTION
## Summary
- add `offload_dir` configuration
- pass `offload_dir` when loading models
- ensure output and offload dirs exist at start

## Testing
- `python -m py_compile gpt5.2_finetune-possibly-the-best-one.py`

------
https://chatgpt.com/codex/tasks/task_e_688b5ecca53c83248e8e86629f0326b8